### PR TITLE
Liliana Add Public Holiday Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -2,8 +2,40 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Public holiday info from nager.date")
+@Slf4j
 @RestController
+@RequestMapping("/api/publicholidays")
 public class PublicHolidaysController {
-    
+   ObjectMapper mapper = new ObjectMapper();
+
+   @Autowired
+   PublicHolidayQueryService publicHolidayQueryService;
+
+   @Operation(summary = "Get the public holidays for a country and year", description = "JSON return format documented here: https://date.nager.at/Api")
+   @GetMapping("/get")
+   public ResponseEntity<String> getPublicHolidays(
+         @Parameter(name = "year", description = "4-digit year", example = "2024") @RequestParam String year,
+         @Parameter(name = "countryCode", description = "country code", example = "us") @RequestParam String countryCode)
+         throws JsonProcessingException {
+      log.info("getPublicHolidays: year={} countryCode={}", year, countryCode);
+      String result = publicHolidayQueryService.getJSON(year, countryCode);
+      return ResponseEntity.ok().body(result);
+   }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -20,7 +20,7 @@ public class PublicHolidayQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -6,8 +6,19 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
+// import com.fasterxml.jackson.databind.ObjectMapper;
+
+// import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -23,9 +34,20 @@ public class PublicHolidayQueryService {
     public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
-        return "";
-    }
+        log.info("year={}, countryCode={}", year, countryCode); 
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
-   
+        Map<String, String> uriVariables = Map.of("year", year,"countryCode", countryCode);
+
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+
+        return re.getBody();
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+@WebMvcTest(value = PublicHolidaysController.class)
+public class PublicHolidayControllerTests {
+   private ObjectMapper mapper = new ObjectMapper();
+   @Autowired
+   private MockMvc mockMvc;
+   @MockBean
+   PublicHolidayQueryService mockPublicHolidayQueryService;
+
+   @Test
+   public void test_getPublicHolidays() throws Exception {
+
+      String fakeJsonResult = "{ \"fake\" : \"result\" }";
+      String year = "2024";
+      String countryCode = "us";
+      when(mockPublicHolidayQueryService.getJSON(eq(year), eq(countryCode))).thenReturn(fakeJsonResult);
+
+      String url = String.format("/api/publicholidays/get?year=%s&countryCode=%s", year, countryCode);
+
+      MvcResult response = mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+      String responseString = response.getResponse().getContentAsString();
+
+      assertEquals(fakeJsonResult, responseString);
+   }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(PublicHolidayQueryService.class)
+public class PublicHolidayQueryServiceTests {
+
+   @Autowired
+   private MockRestServiceServer mockRestServiceServer;
+
+   @Autowired
+   private PublicHolidayQueryService publicHolidayQueryService;
+
+   @Test
+   public void test_getJSON() {
+
+      String countryCode = "US";
+      String year = "2024";
+      String expectedURL = PublicHolidayQueryService.ENDPOINT.replace("{year}", year).replace("{countryCode}", countryCode);
+
+      String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+      this.mockRestServiceServer.expect(requestTo(expectedURL))
+               .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+               .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+               .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+      String actualResult = publicHolidayQueryService.getJSON(year,countryCode);
+      assertEquals(fakeJsonResult, actualResult);
+   }
+}


### PR DESCRIPTION
In this PR, I add an endpoint `/api/publicholidays/get` that can be used to get information
about the public holidays for a country and year. (implemented controller and test)

App deployed at: http://team01-nguyenliliana-dev.dokku-14.cs.ucsb.edu 

Closes #11 